### PR TITLE
Refactor certification processing and update JSON schema

### DIFF
--- a/azure-project-generator/ProcessCertServiceFile.cs
+++ b/azure-project-generator/ProcessCertServiceFile.cs
@@ -38,12 +38,12 @@ namespace azure_project_generator
                 return new CertificationServiceOutput { Document = null, ArchivedContent = null };
             }
 
-            if (!_jsonValidationService.ValidateJsonContent<MappedService>(content))
+            if (!_jsonValidationService.ValidateJsonContent<CertificationService>(content))
             {
                 return new CertificationServiceOutput { Document = null, ArchivedContent = null };
             }
 
-            var mappedServiceData = JsonConvert.DeserializeObject<MappedService>(content);
+            var mappedServiceData = JsonConvert.DeserializeObject<CertificationService>(content);
             if (mappedServiceData == null)
             {
                 _logger.LogError("Failed to deserialize content to MappedService.");
@@ -68,7 +68,7 @@ namespace azure_project_generator
 
         // Other methods remain unchanged
 
-        private CertificationServiceDocument CreateCertServiceDocument(MappedService data, string contextSentence, float[] contentVector) =>
+        private CertificationServiceDocument CreateCertServiceDocument(CertificationService data, string contextSentence, float[] contentVector) =>
            new CertificationServiceDocument
            {
                Id = Guid.NewGuid().ToString(),

--- a/azure-project-generator/Program.cs
+++ b/azure-project-generator/Program.cs
@@ -1,5 +1,6 @@
 using Azure;
 using Azure.AI.OpenAI;
+using Azure.Storage.Blobs;
 using azure_project_generator.services;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.DependencyInjection;
@@ -19,11 +20,15 @@ var host = new HostBuilder()
         string keyFromEnvironment = config["AZURE_OPENAI_API_KEY"];
         string endpointFromEnvironment = config["AZURE_OPENAI_API_ENDPOINT"];
         string embeddingsDeployment = config["EMBEDDINGS_DEPLOYMENT"];
+        string azureWebJobsStorage = config["AzureWebJobsStorage"];
 
         if (string.IsNullOrEmpty(keyFromEnvironment) || string.IsNullOrEmpty(endpointFromEnvironment) || string.IsNullOrEmpty(embeddingsDeployment))
         {
             throw new InvalidOperationException("Required Azure OpenAI configuration is missing.");
         }
+
+        // Register BlobServiceClient as a singleton
+        services.AddSingleton(new BlobServiceClient(azureWebJobsStorage));
 
         AzureOpenAIClient azureClient = new(
             new Uri(endpointFromEnvironment),

--- a/azure-project-generator/azure-project-generator.csproj
+++ b/azure-project-generator/azure-project-generator.csproj
@@ -16,6 +16,8 @@
     <PackageReference Include="Azure.Storage.Blobs" Version="12.21.2" />
     <PackageReference Include="Azure.Storage.Files.Shares" Version="12.19.1" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.19.1" />
+    <PackageReference Include="JsonSchema.Net" Version="7.2.2" />
+    <PackageReference Include="JsonSchema.Net.Generation" Version="4.5.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.23.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.CosmosDB" Version="4.10.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0" />
@@ -25,7 +27,6 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.3.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
-    <PackageReference Include="Newtonsoft.Json.Schema" Version="4.0.1" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/azure-project-generator/models/CertificationService.cs
+++ b/azure-project-generator/models/CertificationService.cs
@@ -2,7 +2,7 @@
 
 namespace azure_project_generator.models
 {
-    public class MappedService
+    public class CertificationService
     {
         [JsonProperty("certificationCode")]
         public string CertificationCode { get; set; }

--- a/azure-project-generator/models/CertificationSkillMeasured.cs
+++ b/azure-project-generator/models/CertificationSkillMeasured.cs
@@ -2,7 +2,7 @@
 
 namespace azure_project_generator.models
 {
-    public class SkillMeasured
+    public class CertificationSkillMeasured
     {
         [Required]
         public string Name { get; set; }

--- a/azure-project-generator/services/ContentGenerationService.cs
+++ b/azure-project-generator/services/ContentGenerationService.cs
@@ -16,7 +16,7 @@ namespace azure_project_generator.services
             _embeddingClient = embeddingClient ?? throw new ArgumentNullException(nameof(embeddingClient));
         }
 
-        public string GenerateCertServiceContextSentence(MappedService data) =>
+        public string GenerateCertServiceContextSentence(CertificationService data) =>
             $"The {data.CertificationCode} {data.CertificationName} certification includes the skill of {data.SkillName}. Within this skill, there is a focus on the topic of {data.TopicName}, particularly through the use of the service {data.ServiceName}.";
 
         public string GenerateCertDataContextSentence(Certification certificationDocument)


### PR DESCRIPTION
Removed ProcessCertPromptFile.cs, MappedService.cs, and SkillMeasured.cs.
Updated ProcessCertServiceFile.cs to use CertificationService.
Registered BlobServiceClient as singleton in Program.cs.
Updated azure-project-generator.csproj to use JsonSchema.Net.
Modified ContentGenerationService.cs to use CertificationService.
Updated JsonValidationService.cs to use JsonSchema.Net.
Added ProcessCertDataFile.cs for processing certification data.
Added CertificationService.cs and CertificationSkillMeasured.cs.